### PR TITLE
Fix virtual display memory leak and resolution reporting

### DIFF
--- a/Sources/HiDPIScaler/Views/MenuBarView.swift
+++ b/Sources/HiDPIScaler/Views/MenuBarView.swift
@@ -131,7 +131,7 @@ struct MenuBarView: View {
             if let display = state.selectedDisplay {
                 HStack(spacing: 12) {
                     InfoBadge(label: "Native",
-                              value: "\(display.pixelWidth)x\(display.pixelHeight)")
+                              value: "\(display.logicalWidth)x\(display.logicalHeight)")
                     InfoBadge(label: "Ratio",
                               value: state.aspectRatioLabel)
                     InfoBadge(label: "Scale",


### PR DESCRIPTION
## Summary

- **Fix Obj-C memory leak**: All `alloc`'d objects (`CGVirtualDisplay`, descriptor, settings, modes) now properly `release`'d under manual retain/release, so virtual displays are fully destroyed on disable and can be re-created
- **Fix resolution reporting**: Use logical dimensions instead of 2x backing pixels for native resolution badge, aspect ratio, and preset generation
- **Filter virtual display from picker**: Hide our virtual display from the display list while active
- **Re-select physical display after disable**: Remember and restore the target display after deactivation

## Test plan

- [ ] Enable HiDPI, disable, re-enable — should succeed without errors
- [ ] Verify virtual display does not appear in the display picker while active
- [ ] Verify "Native" badge shows logical resolution (e.g. 5120x1440), not 2x backing
- [ ] Verify presets don't exceed the display's actual resolution
- [ ] Verify physical display is selected after disabling HiDPI

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)